### PR TITLE
Update to 0.17.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "altgraph" %}
-{% set version = "0.17" %}
+{% set version = "0.17.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,19 +7,20 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/altgraph-{{ version }}.tar.gz
-  sha256: 1f05a47122542f97028caf78775a095fbe6a2699b5089de8477eb583167d69aa
+  sha256: ad33358114df7c9416cdb8fa1eaa5852166c505118717021c6a8c7c7abbd03dd
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
+    - python
     - pip
-    - python >=3.6
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
@@ -37,6 +38,7 @@ about:
       package for constructing graphs, BFS and DFS traversals,
       topological sort, shortest paths, etc. with graphviz output.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   dev_url: https://github.com/ronaldoussoren/altgraph/
   doc_url: https://altgraph.readthedocs.io


### PR DESCRIPTION
Changes:
- Update to 0.17.3
- Remove noarch

Reason: python 3.11 compatibiltiy
https://github.com/ronaldoussoren/altgraph/compare/v0.17...v0.17.3

https://anaconda.atlassian.net/browse/PKG-871